### PR TITLE
Automatic update of Microsoft.Data.Sqlite to 2.2.0

### DIFF
--- a/src/AzureDevOpsKats.Data/AzureDevOpsKats.Data.csproj
+++ b/src/AzureDevOpsKats.Data/AzureDevOpsKats.Data.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Data.Sqlite` to `2.2.0` from `2.1.0`
`Microsoft.Data.Sqlite 2.2.0` was published at `2018-12-04T10:31:56Z`, 7 days ago

1 project update:
Updated `src\AzureDevOpsKats.Data\AzureDevOpsKats.Data.csproj` to `Microsoft.Data.Sqlite` `2.2.0` from `2.1.0`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
