### PR TITLE
Automatic update of Microsoft.Extensions.Logging to 2.2.0

### DIFF
--- a/src/AzureDevOpsKats.Service/AzureDevOpsKats.Service.csproj
+++ b/src/AzureDevOpsKats.Service/AzureDevOpsKats.Service.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Extensions.Logging` to `2.2.0` from `2.1.1`
`Microsoft.Extensions.Logging 2.2.0` was published at `2018-12-04T10:26:37Z`, 7 days ago

1 project update:
Updated `src\AzureDevOpsKats.Service\AzureDevOpsKats.Service.csproj` to `Microsoft.Extensions.Logging` `2.2.0` from `2.1.1`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
