### PR TITLE
Automatic update of Microsoft.EntityFrameworkCore.InMemory to 2.2.0

### DIFF
--- a/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
+++ b/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
@@ -17,7 +17,7 @@
 
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.1.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.EntityFrameworkCore.InMemory` to `2.2.0` from `2.1.4`
`Microsoft.EntityFrameworkCore.InMemory 2.2.0` was published at `2018-12-04T10:34:49Z`, 8 days ago

1 project update:
Updated `test\AzureDevOpsKats.Test\AzureDevOpsKats.Test.csproj` to `Microsoft.EntityFrameworkCore.InMemory` `2.2.0` from `2.1.4`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
