### PR TITLE
Automatic update of Microsoft.Extensions.Configuration.Json to 2.2.0

### DIFF
--- a/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
+++ b/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.Extensions.Configuration.Json` to `2.2.0` from `2.1.1`
`Microsoft.Extensions.Configuration.Json 2.2.0` was published at `2018-12-04T10:29:16Z`, 9 days ago

1 project update:
Updated `test\AzureDevOpsKats.Test\AzureDevOpsKats.Test.csproj` to `Microsoft.Extensions.Configuration.Json` `2.2.0` from `2.1.1`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
