### PR TITLE
Automatic update of Microsoft.AspNetCore.Mvc.Core to 2.2.0

### DIFF
--- a/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
+++ b/test/AzureDevOpsKats.Test/AzureDevOpsKats.Test.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Bogus" Version="25.0.1" />
     <PackageReference Include="FluentAssertions" Version="5.5.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.0" />
 
 
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.4" />


### PR DESCRIPTION
NuKeeper has generated a minor update of `Microsoft.AspNetCore.Mvc.Core` to `2.2.0` from `2.1.1`
`Microsoft.AspNetCore.Mvc.Core 2.2.0` was published at `2018-12-10T10:30:00Z`, 7 days ago

1 project update:
Updated `test\AzureDevOpsKats.Test\AzureDevOpsKats.Test.csproj` to `Microsoft.AspNetCore.Mvc.Core` `2.2.0` from `2.1.1`


This is an automated update. Merge only if it passes tests
**NuKeeper**: https://github.com/NuKeeperDotNet/NuKeeper
