### PR TITLE
feat: Helm chart fixes for k8s deployment + deployment docs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,46 +1,56 @@
 {
-    "editor.formatOnSave": true,
-    "editor.insertSpaces": true,
-    "files.eol": "\n",
-    "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true,
-    "[csharp]": {
-        "editor.tabSize": 4,
-        "editor.defaultFormatter": "ms-dotnettools.csharp"
-    },
-    "[razor]": {
-        "editor.tabSize": 4,
-        "editor.defaultFormatter": "ms-dotnettools.csharp"
-    },
-    "[json]": {
-        "editor.tabSize": 2
-    },
-    "[yaml]": {
-        "editor.tabSize": 2,
-        "editor.defaultFormatter": "redhat.vscode-yaml",
-        "editor.autoIndent": "full"
-    },
-    "[markdown]": {
-        "editor.wordWrap": "on",
-        "files.trimTrailingWhitespace": false
-    },
-    "[dockerfile]": {
-        "editor.tabSize": 4,
-        "editor.defaultFormatter": "ms-azuretools.vscode-docker"
-    },
-    "dotnet.defaultSolution": "AzureDevOpsKats.sln",
-    "omnisharp.enableRoslynAnalyzers": true,
-    "omnisharp.enableEditorConfigSupport": true,
-    "yaml.validate": true,
-    "files.exclude": {
-        "**/bin": true,
-        "**/obj": true,
-        "**/.vs": true,
-        "**/TestResults": true
-    },
-    "search.exclude": {
-        "**/bin": true,
-        "**/obj": true,
-        "**/TestResults": true
-    }
+  "editor.formatOnSave": true,
+  "editor.insertSpaces": true,
+  "files.eol": "\n",
+  "files.insertFinalNewline": true,
+  "files.trimTrailingWhitespace": true,
+  "[csharp]": {
+    "editor.tabSize": 4,
+    "editor.defaultFormatter": "ms-dotnettools.csharp"
+  },
+  "[razor]": {
+    "editor.tabSize": 4,
+    "editor.defaultFormatter": "ms-dotnettools.csharp"
+  },
+  "[json]": {
+    "editor.tabSize": 2
+  },
+  "[yaml]": {
+    "editor.tabSize": 2,
+    "editor.defaultFormatter": "redhat.vscode-yaml",
+    "editor.autoIndent": "full"
+  },
+  "[markdown]": {
+    "editor.wordWrap": "on",
+    "files.trimTrailingWhitespace": false
+  },
+  "[dockerfile]": {
+    "editor.tabSize": 4,
+    "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+  },
+  "dotnet.defaultSolution": "AzureDevOpsKats.sln",
+  "omnisharp.enableRoslynAnalyzers": true,
+  "omnisharp.enableEditorConfigSupport": true,
+  "yaml.validate": true,
+  "yaml.schemas": {
+    "kubernetes": []
+  },
+  "[helm]": {
+    "editor.formatOnSave": false
+  },
+  "files.associations": {
+    "charts/**/templates/*.yaml": "helm",
+    "charts/**/templates/*.tpl": "helm"
+  },
+  "files.exclude": {
+    "**/bin": true,
+    "**/obj": true,
+    "**/.vs": true,
+    "**/TestResults": true
+  },
+  "search.exclude": {
+    "**/bin": true,
+    "**/obj": true,
+    "**/TestResults": true
+  }
 }

--- a/charts/azuredevopskats/templates/deployment.yaml
+++ b/charts/azuredevopskats/templates/deployment.yaml
@@ -15,6 +15,19 @@ spec:
         {{- include "azuredevopskats.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "azuredevopskats.serviceAccountName" . }}
+      {{- with .Values.securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.persistence.enabled }}
+      initContainers:
+        - name: init-permissions
+          image: busybox:1.37
+          command: ["sh", "-c", "chown 1654:1654 /app/data"]
+          volumeMounts:
+            - name: data
+              mountPath: /app/data
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/azuredevopskats/templates/deployment.yaml
+++ b/charts/azuredevopskats/templates/deployment.yaml
@@ -23,7 +23,9 @@ spec:
       initContainers:
         - name: init-permissions
           image: busybox:1.37
-          command: ["sh", "-c", "chown 1654:1654 /app/data"]
+          command: ["sh", "-c", "chown {{ .Values.securityContext.fsGroup }}:{{ .Values.securityContext.fsGroup }} /app/data"]
+          securityContext:
+            runAsUser: 0
           volumeMounts:
             - name: data
               mountPath: /app/data

--- a/charts/azuredevopskats/values.yaml
+++ b/charts/azuredevopskats/values.yaml
@@ -14,7 +14,7 @@ ingress:
   enabled: true
   className: nginx
   annotations:
-    cert-manager.io/cluster-issuer: letsencrypt-prod
+    cert-manager.io/cluster-issuer: letsencrypt-dns01-production
   hosts:
     - host: kats.lab.informationcart.com
       paths:
@@ -27,7 +27,7 @@ ingress:
 
 persistence:
   enabled: true
-  storageClass: nfs-client
+  storageClass: nfs-general
   accessMode: ReadWriteOnce
   size: 1Gi
   mountPath: /app/data
@@ -44,13 +44,16 @@ healthCheck:
   liveness:
     path: /health
     port: 8080
-    initialDelaySeconds: 15
+    initialDelaySeconds: 30
     periodSeconds: 30
   readiness:
     path: /ready
     port: 8080
     initialDelaySeconds: 5
     periodSeconds: 10
+
+securityContext:
+  fsGroup: 1654
 
 serviceAccount:
   create: true

--- a/cspell.json
+++ b/cspell.json
@@ -15,6 +15,7 @@
     "buildtransitive",
     "buildx",
     "bunit",
+    "Cloudflare",
     "configmap",
     "contentfiles",
     "csdevkit",

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -73,7 +73,7 @@ kubectl delete namespace azuredevopskats
 | `image.tag`                      | `latest`                         | Image tag (override at install)    |
 | `ingress.enabled`                | `true`                           | Enable nginx ingress               |
 | `ingress.hosts[0].host`          | `kats.lab.informationcart.com`   | External hostname                  |
-| `ingress.annotations`            | `letsencrypt-dns01-production`   | Cert-manager cluster issuer        |
+| `ingress.annotations.cert-manager.io/cluster-issuer` | `letsencrypt-dns01-production` | Cert-manager cluster issuer |
 | `persistence.enabled`            | `true`                           | Enable PVC for SQLite data         |
 | `persistence.storageClass`       | `nfs-general`                    | NFS CSI storage class              |
 | `persistence.size`               | `1Gi`                            | PVC size                           |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,198 @@
+# AzureDevOpsKats — Kubernetes Deployment Guide
+
+Helm-based deployment of the AzureDevOpsKats Blazor Web App to the
+k8s-pi5-cluster.
+
+## Prerequisites
+
+- `kubectl` configured with `k8s-pi5-cluster` context
+- `helm` v3+ installed
+- Docker Hub image `stuartshay/azuredevopskats` built and pushed
+- DNS record for `kats.lab.informationcart.com` pointing to `192.168.1.100`
+
+## Cluster Details
+
+| Property          | Value                              |
+|-------------------|------------------------------------|
+| Cluster           | k8s-pi5-cluster                    |
+| Namespace         | azuredevopskats                    |
+| Nodes             | 4 (1 master + 3 workers, ARM64)    |
+| Kubernetes        | v1.31.x                            |
+| Ingress           | ingress-nginx (`192.168.1.100`)    |
+| TLS               | cert-manager (Let's Encrypt)       |
+| Storage           | NFS CSI (`nfs-general`)            |
+| DNS               | `kats.lab.informationcart.com`     |
+
+## Deployment
+
+### Install from Local Chart
+
+```bash
+helm install azuredevopskats charts/azuredevopskats \
+  --namespace azuredevopskats --create-namespace \
+  --set image.tag=10.0.5
+```
+
+### Install from GHCR OCI Registry
+
+```bash
+helm install azuredevopskats \
+  oci://ghcr.io/stuartshay/helm-charts/azuredevopskats \
+  --namespace azuredevopskats --create-namespace \
+  --set image.tag=10.0.5
+```
+
+### Upgrade
+
+```bash
+helm upgrade azuredevopskats charts/azuredevopskats \
+  --namespace azuredevopskats \
+  --set image.tag=<new-version>
+```
+
+### Rollback
+
+```bash
+helm rollback azuredevopskats -n azuredevopskats
+```
+
+### Uninstall
+
+```bash
+helm uninstall azuredevopskats -n azuredevopskats
+kubectl delete namespace azuredevopskats
+```
+
+## Configuration
+
+### Key Values (`values.yaml`)
+
+| Value                            | Default                          | Description                        |
+|----------------------------------|----------------------------------|------------------------------------|
+| `image.repository`               | `stuartshay/azuredevopskats`     | Docker Hub image                   |
+| `image.tag`                      | `latest`                         | Image tag (override at install)    |
+| `ingress.enabled`                | `true`                           | Enable nginx ingress               |
+| `ingress.hosts[0].host`          | `kats.lab.informationcart.com`   | External hostname                  |
+| `ingress.annotations`            | `letsencrypt-dns01-production`   | Cert-manager cluster issuer        |
+| `persistence.enabled`            | `true`                           | Enable PVC for SQLite data         |
+| `persistence.storageClass`       | `nfs-general`                    | NFS CSI storage class              |
+| `persistence.size`               | `1Gi`                            | PVC size                           |
+| `securityContext.fsGroup`        | `1654`                           | Group ID for volume ownership      |
+
+### SQLite on NFS
+
+The application uses SQLite stored at `/app/data/cats.sqlite` on an NFS-backed
+PersistentVolume. Two mechanisms ensure the non-root container user (`app`, UID
+1654) can write to the NFS mount:
+
+1. **`fsGroup: 1654`** — Kubernetes sets group ownership on the mounted volume
+2. **`init-permissions` init container** — Runs `chown 1654:1654 /app/data`
+   before the app starts
+
+## Verification
+
+### Check Pod Status
+
+```bash
+kubectl get pods -n azuredevopskats
+```
+
+Expected: `1/1 Running`, `0` restarts.
+
+### Check All Resources
+
+```bash
+kubectl get all,pvc,ingress,certificate -n azuredevopskats
+```
+
+### Health Endpoints
+
+```bash
+# Health (liveness)
+curl -s https://kats.lab.informationcart.com/health
+# Expected: Healthy
+
+# Ready (readiness)
+curl -s https://kats.lab.informationcart.com/ready
+# Expected: Healthy
+```
+
+### TLS Certificate
+
+```bash
+kubectl get certificate -n azuredevopskats
+```
+
+Expected: `READY=True`, issued by Let's Encrypt, valid 90 days.
+
+### Helm Release
+
+```bash
+helm list -n azuredevopskats
+helm get values azuredevopskats -n azuredevopskats
+```
+
+## Troubleshooting
+
+### Pod CrashLoopBackOff
+
+```bash
+kubectl logs -n azuredevopskats -l app.kubernetes.io/name=azuredevopskats
+kubectl describe pod -n azuredevopskats -l app.kubernetes.io/name=azuredevopskats
+```
+
+Common causes:
+
+- **SQLite permission denied**: Check that `securityContext.fsGroup` is set to
+  `1654` and the init container is running. Verify with:
+  `kubectl exec -n azuredevopskats <pod> -- ls -la /app/data/`
+- **PVC not bound**: Check `kubectl get pvc -n azuredevopskats` — status should
+  be `Bound`
+- **Image pull failure**: Verify the image tag exists on Docker Hub
+
+### Ingress Not Working
+
+```bash
+kubectl describe ingress -n azuredevopskats
+kubectl get certificate -n azuredevopskats
+```
+
+Verify DNS resolves: `dig kats.lab.informationcart.com`
+
+### View Logs
+
+```bash
+# Current pod
+kubectl logs -n azuredevopskats -l app.kubernetes.io/name=azuredevopskats
+
+# Previous crashed pod
+kubectl logs -n azuredevopskats -l app.kubernetes.io/name=azuredevopskats --previous
+```
+
+## Architecture
+
+```text
+Internet / LAN
+       │
+       ▼
+┌──────────────────┐
+│  Cloudflare DNS  │  kats.lab.informationcart.com → 192.168.1.100
+└──────────────────┘
+       │
+       ▼
+┌──────────────────┐
+│  ingress-nginx   │  MetalLB LoadBalancer (192.168.1.100)
+│  + cert-manager  │  TLS termination (Let's Encrypt)
+└──────────────────┘
+       │
+       ▼
+┌──────────────────┐
+│  ClusterIP Svc   │  azuredevopskats:80 → pod:8080
+└──────────────────┘
+       │
+       ▼
+┌──────────────────┐
+│  Blazor Web App  │  .NET 10, Kestrel on port 8080
+│  + SQLite DB     │  /app/data/cats.sqlite (NFS PVC)
+└──────────────────┘
+```


### PR DESCRIPTION
## Summary

Fixes the Helm chart to successfully deploy AzureDevOpsKats to the k8s-pi5-cluster and adds deployment documentation.

## Changes

### Helm Chart Fixes
- **`securityContext.fsGroup: 1654`** — Sets volume group ownership so the non-root `app` user (UID 1654) can write to the NFS-backed PVC
- **`init-permissions` init container** — Runs `chown 1654:1654 /app/data` before the app starts to ensure SQLite database creation succeeds on NFS
- **`storageClass: nfs-general`** — Corrected from `nfs-client` to match the cluster's default NFS CSI storage class
- **`cluster-issuer: letsencrypt-dns01-production`** — Corrected from `letsencrypt-prod` to match the actual cert-manager issuer
- **Liveness probe `initialDelaySeconds: 30`** — Increased from 15s to allow for EF Core + SQLite initialization on ARM64

### Documentation
- **`docs/deployment.md`** — Full deployment guide covering install, upgrade, rollback, configuration, verification, troubleshooting, and architecture diagram

## Deployment Verification

Deployed and verified on k8s-pi5-cluster:

| Resource | Status |
|----------|--------|
| Pod | `1/1 Running`, 0 restarts |
| PVC | `Bound`, 1Gi `nfs-general` |
| Ingress | `kats.lab.informationcart.com` → `192.168.1.100` |
| TLS | `Ready`, Let's Encrypt, valid until 2026-05-25 |
| Health | `https://kats.lab.informationcart.com/health` → `Healthy` (200) |
| Home page | `https://kats.lab.informationcart.com/` → 200 |

## Root Cause (CrashLoopBackOff)

The NFS volume mount at `/app/data/` was owned by `root:root` (755), but the container runs as `app` (UID 1654). SQLite couldn't create the database file, causing EF Core `EnsureCreatedAsync` to crash at startup.